### PR TITLE
Fix web assembly freeze - use bevy::utils instead of std::time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+/out

--- a/src/collision.rs
+++ b/src/collision.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use bevy::utils::Duration;
 
 use bevy::{prelude::*, time::common_conditions::on_timer};
 use kd_tree::{KdPoint, KdTree};

--- a/src/enemy.rs
+++ b/src/enemy.rs
@@ -1,5 +1,5 @@
 use std::f32::consts::PI;
-use std::time::Duration;
+use bevy::utils::Duration;
 
 use bevy::math::vec3;
 use bevy::{prelude::*, time::common_conditions::on_timer};

--- a/src/gun.rs
+++ b/src/gun.rs
@@ -1,5 +1,5 @@
 use std::f32::consts::PI;
-use std::time::Instant;
+use bevy::utils::Instant;
 
 use bevy::math::{vec2, vec3};
 use bevy::prelude::*;


### PR DESCRIPTION
After trying to build wasm I got freeze because of `std::time`.
Thanks to guys in Discord server I found a solution.